### PR TITLE
Allure & User Settings tests for Conduit

### DIFF
--- a/src/ui/pages/HomePage.js
+++ b/src/ui/pages/HomePage.js
@@ -6,6 +6,7 @@ export class HomePage {
     this.userId = userId;
     this.yourFeedTab = page.getByText('Your Feed');
     this.newArticleLink = page.getByRole('link', { name: 'New Article' });
+    this.settings = page.getByRole('link', { name: 'Settings' });
   }
 
   async step(title, stepToRun) {
@@ -18,9 +19,21 @@ export class HomePage {
     });
   }
 
+  async clickSettingsLink() {
+    await this.step(`Click the 'Settings' link`, async () => {
+      await this.settings.click();
+    });
+  }
+
   async assertYourFeedTabIsVisible() {
     await this.step(`Assert the 'Your Feed' tab is visible`, async () => {
       await expect(this.yourFeedTab).toBeVisible();
+    });
+  }
+
+  async assertYourFeedTabIsHidden() {
+    await this.step(`Assert the 'Your Feed' tab is hidden`, async () => {
+      await expect(this.yourFeedTab).toBeHidden();
     });
   }
 }

--- a/src/ui/pages/settings/SettingsPage.js
+++ b/src/ui/pages/settings/SettingsPage.js
@@ -1,0 +1,93 @@
+import { expect, testStep } from '../../../common/helpers/pw';
+
+export class SettingsPage {
+  constructor(page, userId = 0) {
+    this.page = page;
+    this.userId = userId;
+    this.profilePictureField = page.getByPlaceholder("URL of profile picture");
+    this.usernameField = page.getByPlaceholder("Username");
+    this.bioField = page.getByPlaceholder("Short bio about you");
+    this.emailField = page.getByPlaceholder("Email");
+    this.passwordField = page.getByPlaceholder("New Password");
+    this.updateBtn = page.getByRole("button", { name: 'Update Settings' });
+    this.logoutBtn = page.getByRole("button",
+      { name: 'Or click here to logout.' });
+  }
+
+  async step(title, stepToRun) {
+    return await testStep(title, stepToRun, this.userId);
+  }
+
+  async fillUsername(username) {
+    await this.step(`Fill in the Username field`, async () => {
+      await this.usernameField.fill(username);
+    });
+  }
+
+  async fillPassword(password) {
+    await this.step(`Fill in the Password field`, async () => {
+      await this.passwordField.fill(password);
+    });
+  }
+
+  async fillEmail(email) {
+    await this.step(`Fill in the Email field`, async () => {
+      await this.emailField.fill(email);
+    });
+  }
+
+  async fillBio(bio) {
+    await this.step(`Fill in the Bio field`, async () => {
+      await this.bioField.fill(bio);
+    });
+  }
+
+  async fillProfilePicture(url) {
+    await this.step(`Fill in the Profile Picture field`, async () => {
+      await this.profilePictureField.fill(url);
+    });
+  }
+
+  async clickUpdateSettingsButton() {
+    await this.step(`Click on the Update Settings button`, async () => {
+      await this.updateBtn.click();
+    });
+  }
+
+  async clickLogoutButton() {
+    await this.step(`Click on the Logout button`, async () => {
+      await this.logoutBtn.click();
+    });
+  }
+
+  async assertUsername(username) {
+    await this.step(`Assert the Username field has correct text`, async () => {
+      await expect(this.usernameField).toHaveValue(username);
+    });
+  }
+
+  async assertPassword(password) {
+    await this.step(`Assert the Username field has correct text'`, async () => {
+      await expect(this.passwordField).toHaveValue(password);
+    });
+  }
+
+  async assertEmail(email) {
+    await this.step(`Assert the Username field has correct text`, async () => {
+      await expect(this.emailField).toHaveValue(email);
+    });
+  }
+
+  async assertBio(bio) {
+    await this.step(`Assert the Bio field has correct text`, async () => {
+      await expect(this.bioField).toHaveValue(bio);
+    });
+  }
+
+  async assertProfilePicture(url) {
+    await this.step(`Assert the Profile Picture field has correct text`,
+      async () => {
+        await expect(this.profilePictureField).toHaveValue(url);
+      });
+  }
+}

--- a/src/ui/pages/settings/SettingsPage.js
+++ b/src/ui/pages/settings/SettingsPage.js
@@ -67,13 +67,13 @@ export class SettingsPage {
   }
 
   async assertPassword(password) {
-    await this.step(`Assert the Username field has correct text'`, async () => {
+    await this.step(`Assert the Password field has correct text'`, async () => {
       await expect(this.passwordField).toHaveValue(password);
     });
   }
 
   async assertEmail(email) {
-    await this.step(`Assert the Username field has correct text`, async () => {
+    await this.step(`Assert the Email field has correct text`, async () => {
       await expect(this.emailField).toHaveValue(email);
     });
   }

--- a/src/ui/pages/settings/SettingsPage.js
+++ b/src/ui/pages/settings/SettingsPage.js
@@ -67,7 +67,7 @@ export class SettingsPage {
   }
 
   async assertPassword(password) {
-    await this.step(`Assert the Password field has correct text'`, async () => {
+    await this.step(`Assert the Password field has correct text`, async () => {
       await expect(this.passwordField).toHaveValue(password);
     });
   }

--- a/tests/_fixtures/fixturesAuth.ts
+++ b/tests/_fixtures/fixturesAuth.ts
@@ -2,12 +2,14 @@ import { test as base } from '@playwright/test';
 import { SignUpPage } from '../../src/ui/pages/auth/SignUpPage';
 import { SignInPage } from '../../src/ui/pages/auth/SignInPage';
 import { HomePage } from '../../src/ui/pages/HomePage';
+import { SettingsPage } from '../../src/ui/pages/settings/SettingsPage';
 
 export const test = base.extend<{
   signUpUsers;
   signUpPage;
   signInPage;
   homePage;
+  settingsPage;
 }>({
   signUpPage: async ({ page }, use) => {
     const signUpPage = new SignUpPage(page);
@@ -23,5 +25,10 @@ export const test = base.extend<{
     const homePage = new HomePage(page);
 
     await use(homePage);
+  },
+  settingsPage: async({ page }, use) => {
+    const settingsPage = new SettingsPage(page);
+
+    await use(settingsPage);
   },
 });

--- a/tests/_fixtures/fixturesGeneric.ts
+++ b/tests/_fixtures/fixturesGeneric.ts
@@ -3,6 +3,7 @@ import { Logger } from '../../src/common/logger/Logger';
 import { generateNewUserData } from '../../src/common/testData/generateNewUserData';
 import * as allure from 'allure-js-commons';
 import { parseTestTreeHierarchy } from '../../src/common/helpers/allureHelpers';
+import fs from 'node:fs';
 
 export const test = base.extend<
   {
@@ -13,6 +14,7 @@ export const test = base.extend<
     users;
     infoTestLog;
     addAllureTestHierarchy;
+    deleteAllureResultsFolder;
   },
   {
     logger;
@@ -84,4 +86,11 @@ export const test = base.extend<
     },
     { scope: 'test', auto: true },
   ],
+  deleteAllureResultsFolder: [
+    async ({}, use)  => {
+      await fs.promises.rm('./allure-results', { recursive: true, force: true });
+      await use();
+    }, 
+    { scope: 'worker', auto: true },
+  ]
 });

--- a/tests/auth/logOut/LogOut.spec.js
+++ b/tests/auth/logOut/LogOut.spec.js
@@ -1,0 +1,22 @@
+import { test } from '../../_fixtures/fixtures';
+import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
+import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
+import { faker } from '@faker-js/faker';
+
+let article;
+
+test.beforeEach(async ({ page, user, logger }) => {
+  article = generateNewArticleData(logger);
+
+  await signUpUser(page, user);
+});
+
+test('Log out user', async ({
+  homePage,
+  settingsPage,
+}) => {
+  await homePage.clickSettingsLink();
+
+  await settingsPage.clickLogoutButton();
+  await homePage.assertYourFeedTabIsHidden();
+});

--- a/tests/auth/logOut/LogOut.spec.js
+++ b/tests/auth/logOut/LogOut.spec.js
@@ -1,13 +1,7 @@
 import { test } from '../../_fixtures/fixtures';
-import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
 import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
-import { faker } from '@faker-js/faker';
-
-let article;
 
 test.beforeEach(async ({ page, user, logger }) => {
-  article = generateNewArticleData(logger);
-
   await signUpUser(page, user);
 });
 

--- a/tests/userSettings/addSettings/addInfo.spec.js
+++ b/tests/userSettings/addSettings/addInfo.spec.js
@@ -1,0 +1,40 @@
+import { test } from '../../_fixtures/fixtures';
+import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
+import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
+import { faker } from '@faker-js/faker';
+
+let article;
+
+test.beforeEach(async ({ page, user, logger }) => {
+  article = generateNewArticleData(logger);
+
+  await signUpUser(page, user);
+});
+
+test('Add profile picture URL from settings', async ({
+  homePage,
+  settingsPage,
+}) => {
+  const urlProfile = 'https://imgflip.com/s/meme/Futurama-Fry.jpg';
+
+  await homePage.clickSettingsLink();
+
+  await settingsPage.fillProfilePicture(urlProfile);
+  await settingsPage.clickUpdateSettingsButton();
+  await homePage.clickSettingsLink();
+  await settingsPage.assertProfilePicture(urlProfile);
+});
+
+test('Add short bio from settings', async ({
+  homePage,
+  settingsPage,
+}) => {
+  const bio = faker.person.bio();
+
+  await homePage.clickSettingsLink();
+
+  await settingsPage.fillBio(bio);
+  await settingsPage.clickUpdateSettingsButton();
+  await homePage.clickSettingsLink();
+  await settingsPage.assertBio(bio);
+});

--- a/tests/userSettings/addSettings/addInfo.spec.js
+++ b/tests/userSettings/addSettings/addInfo.spec.js
@@ -1,13 +1,8 @@
 import { test } from '../../_fixtures/fixtures';
-import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
 import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
 import { faker } from '@faker-js/faker';
 
-let article;
-
 test.beforeEach(async ({ page, user, logger }) => {
-  article = generateNewArticleData(logger);
-
   await signUpUser(page, user);
 });
 

--- a/tests/userSettings/updateSettings/updateInfo.spec.js
+++ b/tests/userSettings/updateSettings/updateInfo.spec.js
@@ -38,13 +38,12 @@ test('Update password from settings', async ({
   homePage,
   signInPage,
   settingsPage,
+  user
 }) => {
-  const email = faker.internet.email().toLowerCase();
   const password = faker.internet.password();
 
   await homePage.clickSettingsLink();
 
-  await settingsPage.fillEmail(email);
   await settingsPage.fillPassword(password);
   await settingsPage.clickUpdateSettingsButton();
 
@@ -52,7 +51,7 @@ test('Update password from settings', async ({
   await settingsPage.clickLogoutButton();
 
   await signInPage.open();
-  await signInPage.fillEmailField(email);
+  await signInPage.fillEmailField(user.email);
   await signInPage.fillPasswordField(password);
   await signInPage.clickSignInButton();
 

--- a/tests/userSettings/updateSettings/updateInfo.spec.js
+++ b/tests/userSettings/updateSettings/updateInfo.spec.js
@@ -1,0 +1,66 @@
+import { test } from '../../_fixtures/fixtures';
+import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
+import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
+import { faker } from '@faker-js/faker';
+
+let article;
+
+const user = {
+  username: faker.internet.username().toLowerCase(),
+  password: faker.internet.password(),
+  email: faker.internet.email().toLowerCase()
+}
+
+test.beforeEach(async ({ page, user, logger }) => {
+  article = generateNewArticleData(logger);
+
+  await signUpUser(page, user);
+});
+
+test('Update username from settings', async ({
+  homePage,
+  settingsPage,
+}) => {
+  await homePage.clickSettingsLink();
+
+  await settingsPage.fillUsername(user.username);
+  await settingsPage.clickUpdateSettingsButton();
+  await homePage.clickSettingsLink();
+  await settingsPage.assertUsername(user.username);
+});
+
+test('Update email from settings', async ({
+  homePage,
+  settingsPage,
+}) => {
+  await homePage.clickSettingsLink();
+
+  await settingsPage.fillEmail(user.email);
+  await settingsPage.clickUpdateSettingsButton();
+  await homePage.clickSettingsLink();
+  await settingsPage.assertEmail(user.email);
+});
+
+test('Update password from settings', async ({
+  homePage,
+  signInPage,
+  settingsPage,
+}) => {
+  await homePage.clickSettingsLink();
+
+  await settingsPage.fillEmail(user.email);
+  await settingsPage.fillPassword(user.password);
+  await settingsPage.clickUpdateSettingsButton();
+
+  await homePage.clickSettingsLink();
+  await settingsPage.clickLogoutButton();
+
+  await signInPage.open();
+  await signInPage.fillEmailField(user.email);
+  await signInPage.fillPasswordField(user.password);
+  await signInPage.clickSignInButton();
+
+  await homePage.assertYourFeedTabIsVisible();
+});
+
+

--- a/tests/userSettings/updateSettings/updateInfo.spec.js
+++ b/tests/userSettings/updateSettings/updateInfo.spec.js
@@ -1,19 +1,8 @@
 import { test } from '../../_fixtures/fixtures';
-import { generateNewArticleData } from '../../../src/common/testData/generateNewArticleData';
 import { signUpUser } from '../../../src/ui/actions/auth/signUpUser';
 import { faker } from '@faker-js/faker';
 
-let article;
-
-const user = {
-  username: faker.internet.username().toLowerCase(),
-  password: faker.internet.password(),
-  email: faker.internet.email().toLowerCase()
-}
-
 test.beforeEach(async ({ page, user, logger }) => {
-  article = generateNewArticleData(logger);
-
   await signUpUser(page, user);
 });
 
@@ -21,24 +10,28 @@ test('Update username from settings', async ({
   homePage,
   settingsPage,
 }) => {
+  const username = faker.internet.username().toLowerCase();
+
   await homePage.clickSettingsLink();
 
-  await settingsPage.fillUsername(user.username);
+  await settingsPage.fillUsername(username);
   await settingsPage.clickUpdateSettingsButton();
   await homePage.clickSettingsLink();
-  await settingsPage.assertUsername(user.username);
+  await settingsPage.assertUsername(username);
 });
 
 test('Update email from settings', async ({
   homePage,
   settingsPage,
 }) => {
+  const email = faker.internet.email().toLowerCase();
+
   await homePage.clickSettingsLink();
 
-  await settingsPage.fillEmail(user.email);
+  await settingsPage.fillEmail(email);
   await settingsPage.clickUpdateSettingsButton();
   await homePage.clickSettingsLink();
-  await settingsPage.assertEmail(user.email);
+  await settingsPage.assertEmail(email);
 });
 
 test('Update password from settings', async ({
@@ -46,18 +39,21 @@ test('Update password from settings', async ({
   signInPage,
   settingsPage,
 }) => {
+  const email = faker.internet.email().toLowerCase();
+  const password = faker.internet.password();
+
   await homePage.clickSettingsLink();
 
-  await settingsPage.fillEmail(user.email);
-  await settingsPage.fillPassword(user.password);
+  await settingsPage.fillEmail(email);
+  await settingsPage.fillPassword(password);
   await settingsPage.clickUpdateSettingsButton();
 
   await homePage.clickSettingsLink();
   await settingsPage.clickLogoutButton();
 
   await signInPage.open();
-  await signInPage.fillEmailField(user.email);
-  await signInPage.fillPasswordField(user.password);
+  await signInPage.fillEmailField(email);
+  await signInPage.fillPasswordField(password);
   await signInPage.clickSignInButton();
 
   await homePage.assertYourFeedTabIsVisible();


### PR DESCRIPTION
1. Created the following new tests under the userSettings folder, added subfolder:

- Update username from settings
- Update email from settings
- Update password from settings
- Add profile picture URL from settings
- Add short bio from settings

2. Created a single new test in the auth folder, added subfolder:

- Log out user

3. Created an auto worker-scope fixture, so that the the allure-results folder is deleted before before the tests are executed.